### PR TITLE
Fix parsing of big integers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 
     "autoload": {
         "psr-0": {
-            "JsonStreamingParser": "src/"
+            "JsonStreamingParser\\": "src/"
         }
     }
 }

--- a/src/JsonStreamingParser/Parser.php
+++ b/src/JsonStreamingParser/Parser.php
@@ -531,11 +531,16 @@ class Parser
     private function endNumber()
     {
         $num = $this->buffer;
-        if (preg_match('/\./', $num)) {
-            $num = (float) ($num);
-        } else {
-            $num = (int) ($num);
+
+        if (ctype_digit($num) && ((float)$num === (float)((int)$num))) {
+            // natural number PHP_INT_MIN < $num < PHP_INT_MAX
+            $num = (int)$num;
         }
+        else {
+            // real number or natural number outside PHP_INT_MIN ... PHP_INT_MAX
+            $num = (float)$num;
+        }
+
         $this->listener->value($num);
 
         $this->buffer = '';


### PR DESCRIPTION
This needs to be handled in the parser as listener would only see `PHP_INT_MAX` otherwise.

The composer recommendation on namespaces can be found here https://getcomposer.org/doc/04-schema.md#autoload
